### PR TITLE
Make apoc as env variable in neo4j

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         image: 'neo4j:4.1.0-enterprise'
         env:
           NEO4J_AUTH: 'neo4j/test'
-          NEO4JLABS_PLUGINS: "[\"apoc\"]"
+          NEO4JLABS_PLUGINS: '["apoc"]'
         ports: 
           - 7474:7474
           - 7687:7687

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Compile
       run: sbt ";compile ;test:compile"
 
-    - name: Run tests (require Neo4j without APOC plugin)
+    - name: Run tests (require Neo4j with APOC plugin)
       env:
         NEO4J_HOST: 'localhost'
         NEO4J_AUTH: 'neo4j/test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ jobs:
 
     services:
       neo4j:
-        image: neo4j:latest
+        image: 'neo4j:4.1.0-enterprise'
         env:
           NEO4J_AUTH: 'neo4j/test'
+          NEO4JLABS_PLUGINS: "[\"apoc\"]"
         ports: 
           - 7474:7474
           - 7687:7687
@@ -30,19 +31,9 @@ jobs:
 
     - name: Compile
       run: sbt ";compile ;test:compile"
-    
-    - name: Run tests (not require Neo4j)
-      run: sbt "testOnly * -- -l com.arkondata.slothql.test.tags.RequiresNeo4j"
-      
+
     - name: Run tests (require Neo4j without APOC plugin)
       env:
         NEO4J_HOST: 'localhost'
         NEO4J_AUTH: 'neo4j/test'
-      run: sbt "testOnly * -- -n com.arkondata.slothql.test.tags.RequiresNeo4j -l com.arkondata.slothql.test.tags.RequiresApoc"
-
-    - name: "[DISABLED] Run tests (require Neo4j with APOC plugin)"
-      env:
-        NEO4J_HOST: 'localhost'
-        NEO4J_AUTH: 'neo4j/test'
-      run: echo "DISABLED"
-      # run: sbt "testOnly * -- -n com.arkondata.slothql.test.tags.RequiresNeo4j -n com.arkondata.slothql.test.tags.RequiresApoc"
+      run: sbt test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         ports: 
           - 7474:7474
           - 7687:7687
-        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 20s --health-timeout 100s --health-retries 5
+        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 100s --health-timeout 100s --health-retries 5
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
         image: 'neo4j:4.1.0-enterprise'
         env:
           NEO4J_AUTH: 'neo4j/test'
-          NEO4JLABS_PLUGINS: ['apoc']
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: 'yes'
+          NEO4JLABS_PLUGINS: '["apoc"]'
         ports: 
           - 7474:7474
           - 7687:7687

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         image: 'neo4j:4.1.0-enterprise'
         env:
           NEO4J_AUTH: 'neo4j/test'
-          NEO4JLABS_PLUGINS: '["apoc"]'
+          NEO4JLABS_PLUGINS: ['apoc']
         ports: 
           - 7474:7474
           - 7687:7687

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         ports: 
           - 7474:7474
           - 7687:7687
-        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 100s --health-timeout 100s --health-retries 5
+        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 30s --health-timeout 180s --health-retries 6
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         ports: 
           - 7474:7474
           - 7687:7687
-        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 30s --health-timeout 180s --health-retries 6
+        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 10s --health-timeout 180s --health-retries 18
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         ports: 
           - 7474:7474
           - 7687:7687
-        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 20s --health-timeout 10s --health-retries 5
+        options: --health-cmd "wget --quiet --spider localhost:7474" --health-interval 20s --health-timeout 100s --health-retries 5
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -14,20 +14,17 @@ export GID
 
 COMPOSE_CMD = docker-compose -p $(BRANCH_NAME)
 
-neo4j/plugins/apoc-4.1.0.0-all.jar:
-	curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/4.1.0.0/apoc-4.1.0.0-all.jar -o neo4j/plugins/apoc-4.1.0.0-all.jar
-
-start_dependencies: neo4j/plugins/apoc-4.1.0.0-all.jar
+start_dependencies:
 	$(COMPOSE_CMD) -f cicd/docker-compose.deps.yml --env-file ../.env up -d -V
 
 stop_dependencies:
 	$(COMPOSE_CMD) -f cicd/docker-compose.deps.yml down -v
 
 
-ps: neo4j/plugins/apoc-4.1.0.0-all.jar
+ps:
 	$(COMPOSE_CMD) -f cicd/docker-compose.deps.yml --env-file ../.env ps
 
-logs: neo4j/plugins/apoc-4.1.0.0-all.jar
+logs:
 	$(COMPOSE_CMD) -f cicd/docker-compose.deps.yml --env-file ../.env logs -f
 
 sbt:

--- a/cicd/docker-compose.deps.yml
+++ b/cicd/docker-compose.deps.yml
@@ -9,11 +9,11 @@ services:
     environment:
       NEO4J_AUTH: ${NEO4J_AUTH-neo4j/test123}
       NEO4J_ACCEPT_LICENSE_AGREEMENT: 'yes'
+      NEO4JLABS_PLUGINS: "[\"apoc\"]"
     healthcheck:
       test: ["CMD", "wget", "--spider", "0.0.0.0:7474"]
       interval: 10s
       timeout: 10s
       retries: 10
     volumes:
-      - ../neo4j/plugins:/plugins
       - ../neo4j/conf:/conf


### PR DESCRIPTION
### Make apoc as env variable in neo4j

Use `NEO4JLABS_PLUGINS` instead manually download and install apoc plugin.

This env search for plugin version in [the offical version matrix of neo4j](https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json)