### PR TITLE
Cu jpz3xw improve field service creation

### DIFF
--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -6,6 +6,8 @@ import cats.data.{ Ior, NonEmptyList }
 import cats.instances.list._
 import cats.instances.option._
 
+import com.arkondata.slothql.cypher.syntax.LiftedMap
+
 trait CypherFragment {
   type Statement <: CypherStatement
 
@@ -496,6 +498,8 @@ object CypherFragment {
       }
     }
 
+    case class SetNode(to: Expr[Map[String, _]], props: Expr[Map[String, Expr[_]]]) extends Write
+
     def toCypher(clause: Clause): GenS[Part] = clause match {
       case Match(pattern, optional, where) =>
         for {
@@ -517,6 +521,12 @@ object CypherFragment {
         } yield s"WITH $ret$where"
       case Create(pattern) => partsSequence(pattern.toList).map(ps => s"CREATE ${ps.mkString(", ")}")
       case SetProps(set)   => partsSequence(set.toList).map(ss => s"SET ${ss.mkString(", ")}")
+      case SetNode(n, props0) =>
+        for {
+          name  <- part(n)
+          props <- part(props0)
+          set   <- GenS.part(s"SET $name = $props")
+        } yield set
       case Delete(elems, detach) =>
         val detachStr = if (detach) "DETACH " else ""
         partsSequence(elems.toList).map(es => s"${detachStr}DELETE ${es.mkString(", ")}")

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -500,6 +500,8 @@ object CypherFragment {
 
     case class SetNode(to: Expr[Map[String, _]], props: Expr[Map[String, Expr[_]]]) extends Write
 
+    case class ExtendNode(to: Expr[Map[String, _]], props: Expr[Map[String, Expr[_]]]) extends Write
+
     def toCypher(clause: Clause): GenS[Part] = clause match {
       case Match(pattern, optional, where) =>
         for {
@@ -526,6 +528,12 @@ object CypherFragment {
           name  <- part(n)
           props <- part(props0)
           set   <- GenS.part(s"SET $name = $props")
+        } yield set
+      case ExtendNode(n, props0) =>
+        for {
+          name  <- part(n)
+          props <- part(props0)
+          set   <- GenS.part(s"SET $name += $props")
         } yield set
       case Delete(elems, detach) =>
         val detachStr = if (detach) "DETACH " else ""

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -182,6 +182,11 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
         CF.Clause.SetProps(NonEmptyList(prop, props.toList)),
         res
       )
+
+    def apply[R](setNode: CF.Clause.SetNode)(res: Query[R]): Query[R] = CF.Query.Clause(
+      setNode,
+      res
+    )
   }
 
   object Delete {
@@ -879,6 +884,10 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       def updateDynamic[V](prop: String)(value: Expr[V]): Update.Prop =
         CF.Clause.SetProps.One(e.asInstanceOf[Expr[Map[String, Any]]], prop, value)
     }
+
+    def :=(props: Expr[Map[String, Expr[_]]]): CF.Clause.SetNode =
+      CF.Clause.SetNode(e.asInstanceOf[Expr[Map[String, Any]]], props)
+
     def setProp: set.type = set
   }
 

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -187,6 +187,11 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       setNode,
       res
     )
+
+    def apply[R](setNode: CF.Clause.ExtendNode)(res: Query[R]): Query[R] = CF.Query.Clause(
+      setNode,
+      res
+    )
   }
 
   object Delete {
@@ -887,6 +892,9 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
 
     def :=(props: Expr[Map[String, Expr[_]]]): CF.Clause.SetNode =
       CF.Clause.SetNode(e.asInstanceOf[Expr[Map[String, Any]]], props)
+
+    def +=(props: Expr[Map[String, Expr[_]]]): CF.Clause.ExtendNode =
+      CF.Clause.ExtendNode(e.asInstanceOf[Expr[Map[String, Any]]], props)
 
     def setProp: set.type = set
   }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -45,6 +45,18 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       "RETURN `id`(`n0`)"
     ).returns[Long]
 
+    "support settings node properties from map extending properties" in
+    test(
+      Match { case n @ Node("id" := "123") =>
+        Update(n += lit(Map("foo" -> lit("qwerty")))) {
+          n.id
+        }
+      },
+      "MATCH (`n0`{ `id`: \"123\" }) " +
+      "SET `n0` += {`foo`: \"qwerty\"} " +
+      "RETURN `id`(`n0`)"
+    ).returns[Long]
+
     "support setting relationship properties" in
     test(
       Match { case (a @ Node("A")) - (e @ Rel("E")) > (b @ Node("B")) =>

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -33,6 +33,18 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       "RETURN `id`(`n0`)"
     ).returns[Long]
 
+    "support settings node properties from map" in
+    test(
+      Match { case n @ Node("id" := "123") =>
+        Update(n := lit(Map("foo" -> lit("qwerty")))) {
+          n.id
+        }
+      },
+      "MATCH (`n0`{ `id`: \"123\" }) " +
+      "SET `n0` = {`foo`: \"qwerty\"} " +
+      "RETURN `id`(`n0`)"
+    ).returns[Long]
+
     "support setting relationship properties" in
     test(
       Match { case (a @ Node("A")) - (e @ Rel("E")) > (b @ Node("B")) =>


### PR DESCRIPTION
Support for SET `Node` syntax

Docs: https://neo4j.com/docs/cypher-manual/current/clauses/set/#set-setting-properties-using-map

``` cypher
MATCH (n {name: 'Andy'})
SET n = $props
RETURN n.name, n.position, n.age, n.hungry
```
```cypher
MATCH (p {name: 'Peter'})
SET p += {age: 38, hungry: true, position: 'Entrepreneur'}
RETURN p.name, p.age, p.hungry, p.position
```
