### PR TITLE
support any convertible map like `LiftedMap`

### DIFF
--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -893,8 +893,8 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     def :=(props: Expr[Map[String, Expr[_]]]): CF.Clause.SetNode =
       CF.Clause.SetNode(e.asInstanceOf[Expr[Map[String, Any]]], props)
 
-    def +=(props: Expr[Map[String, Expr[_]]]): CF.Clause.ExtendNode =
-      CF.Clause.ExtendNode(e.asInstanceOf[Expr[Map[String, Any]]], props)
+    def +=[A](props: Expr[Map[String, A]]): CF.Clause.ExtendNode =
+      CF.Clause.ExtendNode(e.asInstanceOf[Expr[Map[String, Any]]], props.asInstanceOf[Expr[Map[String, Expr[_]]]])
 
     def setProp: set.type = set
   }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -57,6 +57,18 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       "RETURN `id`(`n0`)"
     ).returns[Long]
 
+    "support settings node properties from map extending properties with lifted map" in
+    test(
+      Match { case n @ Node("id" := "123") =>
+        Update(n += lit(LiftedMap("foo" -> "qwerty", "bar" -> 123))) {
+          n.id
+        }
+      },
+      "MATCH (`n0`{ `id`: \"123\" }) " +
+      "SET `n0` += {`foo`: \"qwerty\", `bar`: 123} " +
+      "RETURN `id`(`n0`)"
+    ).returns[Long]
+
     "support setting relationship properties" in
     test(
       Match { case (a @ Node("A")) - (e @ Rel("E")) > (b @ Node("B")) =>


### PR DESCRIPTION
### support any convertible map like `LiftedMap`

Since `.asInstanceOf[Expr[Map[String, Expr[_]]]]` convert to any A that contains `toCypherF` method.