### PR TITLE
Merge syntax

### DIFF
--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -482,6 +482,8 @@ object CypherFragment {
     case class Create(pattern: PatternTuple) extends Write
     case class Delete(elems: NonEmptyList[Expr[_]], detach: Boolean) extends Write
 
+    case class OnMatch(props: Write) extends Write
+
     case class SetProps(set: NonEmptyList[SetProps.One]) extends Write
 
     object SetProps {
@@ -514,6 +516,10 @@ object CypherFragment {
         for {
           ps <- partsSequence(pattern.toList)
         } yield s"MERGE ${ps.mkString(", ")}"
+      case OnMatch(props) =>
+        for {
+          ps <- part(props)
+        } yield s"ON MATCH $ps"
       case Unwind(expr, as) =>
         for {
           expr  <- part(expr)

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -484,6 +484,8 @@ object CypherFragment {
 
     case class OnMatch(props: Write) extends Write
 
+    case class OnCreate(props: Write) extends Write
+
     case class SetProps(set: NonEmptyList[SetProps.One]) extends Write
 
     object SetProps {
@@ -520,6 +522,10 @@ object CypherFragment {
         for {
           ps <- part(props)
         } yield s"ON MATCH $ps"
+      case OnCreate(props) =>
+        for {
+          ps <- part(props)
+        } yield s"ON CREATE $ps"
       case Unwind(expr, as) =>
         for {
           expr  <- part(expr)

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -470,6 +470,8 @@ object CypherFragment {
     case class With(ret: Return[_], where: Option[Expr[Boolean]]) extends Read
     case class Unwind(expr: Expr[Seq[_]], as: Alias) extends Read
 
+    case class Merge(pattern: PatternTuple) extends Write
+
     case class Call(
       procedure: String,
       params: List[Expr[_]],
@@ -508,6 +510,10 @@ object CypherFragment {
           opt <- part(if (optional) "OPTIONAL " else "")
           wh  <- part(wh0.map(w => s" WHERE $w").getOrElse(""))
         } yield s"${opt}MATCH ${ps.mkString(", ")}$wh"
+      case Merge(pattern) =>
+        for {
+          ps <- partsSequence(pattern.toList)
+        } yield s"MERGE ${ps.mkString(", ")}"
       case Unwind(expr, as) =>
         for {
           expr  <- part(expr)

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -47,6 +47,30 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     )
   }
 
+  /** To use inside MERGE clause
+    */
+  object OnCreate extends {
+    type Prop = CF.Clause.SetProps.One
+
+    case class PartialCreateApply(clause: Write) {
+
+      def *>[R](res: Query[R]): Query[R] = CF.Query.Clause(
+        clause,
+        res
+      )
+    }
+
+    def apply(prop: Prop, props: Prop*): PartialCreateApply = PartialCreateApply(
+      CF.Clause.OnCreate(CF.Clause.SetProps(NonEmptyList(prop, props.toList)))
+    )
+
+    def apply(setNode: CF.Clause.SetNode): PartialCreateApply = PartialCreateApply(CF.Clause.OnCreate(setNode))
+
+    def apply(extendNode: CF.Clause.ExtendNode): PartialCreateApply = PartialCreateApply(
+      CF.Clause.OnCreate(extendNode)
+    )
+  }
+
   object With extends {
 
     @compileTimeOnly("would have been replaced at With.apply")

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -22,6 +22,30 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       macro CypherSyntaxPatternMacros.maybe[R]
   }
 
+  /** To use inside MERGE clause
+    */
+  object OnMatch extends {
+    type Prop = CF.Clause.SetProps.One
+
+    def apply[R](prop: Prop, props: Prop*)(res: Query[R]): Query[R] =
+      CF.Query.Clause(
+        CF.Clause.OnMatch(CF.Clause.SetProps(NonEmptyList(prop, props.toList))),
+        res
+      )
+
+    def apply[R](setNode: CF.Clause.SetNode)(res: Query[R]): Query[R] =
+      CF.Query.Clause(
+        CF.Clause.OnMatch(setNode),
+        res
+      )
+
+    def apply[R](extendNode: CF.Clause.ExtendNode)(res: Query[R]): Query[R] =
+      CF.Query.Clause(
+        CF.Clause.OnMatch(extendNode),
+        res
+      )
+  }
+
   object With extends {
 
     @compileTimeOnly("would have been replaced at With.apply")

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -170,7 +170,7 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
   }
 
   object Merge {
-    // def apply[R](query: Node => CF.Query[R]): CF.Query[R] = macro CypherSyntaxPatternMacros.merge[R]
+    def apply[R](query: Node => CF.Query.Query0[R]): CF.Query.Query0[R] = macro CypherSyntaxPatternMacros.merge[R]
   }
 
   object Update {

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -112,6 +112,14 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       },
       "CREATE (:`Foo`{ `id`: 1 }) "
     ).returns[Unit]
+
+    "support merge nodes" in
+    test(
+      Merge { case Node("Foo", "bar" := 1, "another" := "stub") =>
+        returnNothing
+      },
+      "MERGE (:`Foo`{ `bar`: 1, `another`: \"stub\" }) "
+    ).returns[Unit]
   }
 
 }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -132,20 +132,18 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
     "support merge nodes with on match with set" in
     test(
       Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
-        OnMatch(n.set.id = lit(2)) {
-          returnNothing
-        }
+        OnMatch(n.set.id := lit(2), n.set.bar := lit("stub")) *>
+        returnNothing
       },
       "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
-      "ON MATCH SET `n0`.`id` = 2 "
+      "ON MATCH SET `n0`.`id` = 2, `n0`.`bar` = \"stub\" "
     ).returns[Unit]
 
     "support merge nodes with on match with set node" in
     test(
       Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
-        OnMatch(n := lit(Map("id" -> lit(2)))) {
-          returnNothing
-        }
+        OnMatch(n := lit(Map("id" -> lit(2)))) *>
+        returnNothing
       },
       "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
       "ON MATCH SET `n0` = {`id`: 2} "
@@ -154,9 +152,8 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
     "support merge nodes with on match with extend node" in
     test(
       Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
-        OnMatch(n += lit(Map("id" -> lit(2)))) {
-          returnNothing
-        }
+        OnMatch(n += lit(Map("id" -> lit(2)))) *>
+        returnNothing
       },
       "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
       "ON MATCH SET `n0` += {`id`: 2} "

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -189,6 +189,32 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       "ON CREATE SET `n0` += {`id`: 2} "
     ).returns[Unit]
 
+    "support merge nodes with on create and on match with return" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnMatch(n += lit(Map("id" -> lit(3)))) *>
+        OnCreate(n += lit(Map("id" -> lit(2)))) *>
+        n
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON MATCH SET `n0` += {`id`: 3} " +
+      "ON CREATE SET `n0` += {`id`: 2} " +
+      "RETURN `n0`"
+    ).returns[GraphElem.Node]
+
+    "support merge nodes with on match and on create with return" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnCreate(n += lit(Map("id" -> lit(2)))) *>
+        OnMatch(n += lit(Map("id" -> lit(3)))) *>
+        n
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON MATCH SET `n0` += {`id`: 3} " +
+      "ON CREATE SET `n0` += {`id`: 2} " +
+      "RETURN `n0`"
+    ).returns[GraphElem.Node]
+
   }
 
 }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -159,6 +159,36 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
       "ON MATCH SET `n0` += {`id`: 2} "
     ).returns[Unit]
 
+    "support merge nodes with on create with set" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnCreate(n.set.id := lit(2), n.set.bar := lit("stub")) *>
+        returnNothing
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON CREATE SET `n0`.`id` = 2, `n0`.`bar` = \"stub\" "
+    ).returns[Unit]
+
+    "support merge nodes with on create with set node" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnCreate(n := lit(Map("id" -> lit(2)))) *>
+        returnNothing
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON CREATE SET `n0` = {`id`: 2} "
+    ).returns[Unit]
+
+    "support merge nodes with on create with extend node" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnCreate(n += lit(Map("id" -> lit(2)))) *>
+        returnNothing
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON CREATE SET `n0` += {`id`: 2} "
+    ).returns[Unit]
+
   }
 
 }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWriteSpec.scala
@@ -115,11 +115,53 @@ class CypherSyntaxWriteSpec extends CypherSyntaxBaseSpec {
 
     "support merge nodes" in
     test(
-      Merge { case Node("Foo", "bar" := 1, "another" := "stub") =>
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
         returnNothing
       },
-      "MERGE (:`Foo`{ `bar`: 1, `another`: \"stub\" }) "
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) "
     ).returns[Unit]
+
+    "support merge nodes with relations" in
+    test(
+      Merge { case (n @ Node("Foo", "bar" := 1, "another" := "stub")) - Rel("do") > Node("Bar") =>
+        returnNothing
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) -[:`do`]-> (:`Bar`) "
+    ).returns[Unit]
+
+    "support merge nodes with on match with set" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnMatch(n.set.id = lit(2)) {
+          returnNothing
+        }
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON MATCH SET `n0`.`id` = 2 "
+    ).returns[Unit]
+
+    "support merge nodes with on match with set node" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnMatch(n := lit(Map("id" -> lit(2)))) {
+          returnNothing
+        }
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON MATCH SET `n0` = {`id`: 2} "
+    ).returns[Unit]
+
+    "support merge nodes with on match with extend node" in
+    test(
+      Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
+        OnMatch(n += lit(Map("id" -> lit(2)))) {
+          returnNothing
+        }
+      },
+      "MERGE (`n0`:`Foo`{ `bar`: 1, `another`: \"stub\" }) " +
+      "ON MATCH SET `n0` += {`id`: 2} "
+    ).returns[Unit]
+
   }
 
 }


### PR DESCRIPTION
### Support for MERGE Syntax

https://neo4j.com/docs/cypher-manual/current/clauses/merge/

Allow a syntax like this.

```scala
Merge { case n @ Node("Foo", "bar" := 1, "another" := "stub") =>
     OnCreate(n += lit(Map("id" -> lit(2)))) *>
     OnMatch(n += lit(Map("id" -> lit(3)))) *>
     n
}
```

### Test?
```bash
make start_dependencies sbt
sbt> test
```