### PR TITLE
Preserve syntax

### DIFF
--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -115,6 +115,8 @@ object CypherFragment {
       def apply[A](name: String): Alias[A] = new Alias(name)
 
       final case class Fixed[+A](override val name: String) extends Alias[A](name) with CypherStatement.Alias.Fixed
+
+      final case class Preserving(exprs: Seq[Expr[_] with CypherStatement.Alias])
     }
 
     final case class Func[+A](func: String, params: List[Expr[_]]) extends Expr[A]

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/CypherFragment.scala
@@ -116,7 +116,10 @@ object CypherFragment {
 
       final case class Fixed[+A](override val name: String) extends Alias[A](name) with CypherStatement.Alias.Fixed
 
-      final case class Preserving(exprs: Seq[Expr[_] with CypherStatement.Alias])
+      final case class Preserving(expressions: Seq[Expr[_] with CypherStatement.Alias]) {
+        def also(others: Seq[Expr[_] with CypherStatement.Alias]): Preserving = Preserving(expressions ++ others)
+        def and(others: Expr[_] with CypherStatement.Alias*): Preserving      = Preserving(expressions ++ others)
+      }
     }
 
     final case class Func[+A](func: String, params: List[Expr[_]]) extends Expr[A]

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWithMacros.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWithMacros.scala
@@ -5,6 +5,7 @@ import scala.reflect.macros.blackbox
 
 import cats.data.NonEmptyList
 
+import com.arkondata.slothql.cypher.CypherFragment.Expr.Alias.Preserving
 import com.arkondata.slothql.cypher.{ CypherFragment => CF }
 
 class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyntaxPatternMacros(c) {
@@ -13,12 +14,12 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
   def with1[T1: WeakTypeTag, R: WeakTypeTag](t1: c.Expr[CF.Expr[T1]])(
     query: c.Expr[CF.Expr.Alias[T1] => CF.Query.Query0[R]]
   ): c.Expr[CF.Query.Query0[R]] =
-    withImpl(query.tree, wildcard = false, t1.tree -> weakTypeOf[T1])
+    withImpl(query.tree, wildcard = false, None, t1.tree -> weakTypeOf[T1])
 
   def with2[T1: WeakTypeTag, T2: WeakTypeTag, R: WeakTypeTag](t1: c.Expr[CF.Expr[T1]], t2: c.Expr[CF.Expr[T2]])(
     query: c.Expr[(CF.Expr.Alias[T1], CF.Expr.Alias[T2]) => CF.Query.Query0[R]]
   ): c.Expr[CF.Query.Query0[R]] =
-    withImpl(query.tree, wildcard = false, t1.tree -> weakTypeOf[T1], t2.tree -> weakTypeOf[T2])
+    withImpl(query.tree, wildcard = false, None, t1.tree -> weakTypeOf[T1], t2.tree -> weakTypeOf[T2])
 
   def with3[T1: WeakTypeTag, T2: WeakTypeTag, T3: WeakTypeTag, R: WeakTypeTag](
     t1: c.Expr[CF.Expr[T1]],
@@ -30,6 +31,7 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = false,
+      None,
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3]
@@ -46,6 +48,7 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = false,
+      None,
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3],
@@ -72,6 +75,7 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = false,
+      None,
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3],
@@ -82,19 +86,19 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
   def withWild0[R: WeakTypeTag](wildcard: c.Expr[**.type])(
     query: c.Expr[CF.Query.Query0[R]]
   ): c.Expr[CF.Query.Query0[R]] =
-    withImpl(query.tree, wildcard = true)
+    withImpl(query.tree, wildcard = true, None)
 
   def withWild1[T1: WeakTypeTag, R: WeakTypeTag](wildcard: c.Expr[**.type], t1: c.Expr[CF.Expr[T1]])(
     query: c.Expr[CF.Expr.Alias[T1] => CF.Query.Query0[R]]
   ): c.Expr[CF.Query.Query0[R]] =
-    withImpl(query.tree, wildcard = true, t1.tree -> weakTypeOf[T1])
+    withImpl(query.tree, wildcard = true, None, t1.tree -> weakTypeOf[T1])
 
   def withWild2[T1: WeakTypeTag, T2: WeakTypeTag, R: WeakTypeTag](
     wildcard: c.Expr[**.type],
     t1: c.Expr[CF.Expr[T1]],
     t2: c.Expr[CF.Expr[T2]]
   )(query: c.Expr[(CF.Expr.Alias[T1], CF.Expr.Alias[T2]) => CF.Query.Query0[R]]): c.Expr[CF.Query.Query0[R]] =
-    withImpl(query.tree, wildcard = true, t1.tree -> weakTypeOf[T1], t2.tree -> weakTypeOf[T2])
+    withImpl(query.tree, wildcard = true, None, t1.tree -> weakTypeOf[T1], t2.tree -> weakTypeOf[T2])
 
   def withWild3[T1: WeakTypeTag, T2: WeakTypeTag, T3: WeakTypeTag, R: WeakTypeTag](
     wildcard: c.Expr[**.type],
@@ -107,6 +111,7 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = true,
+      None,
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3]
@@ -124,6 +129,7 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = true,
+      None,
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3],
@@ -151,6 +157,97 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
     withImpl(
       query.tree,
       wildcard = true,
+      None,
+      t1.tree -> weakTypeOf[T1],
+      t2.tree -> weakTypeOf[T2],
+      t3.tree -> weakTypeOf[T3],
+      t4.tree -> weakTypeOf[T4],
+      t5.tree -> weakTypeOf[T5]
+    )
+
+  def withPreserving1[T1: WeakTypeTag, R: WeakTypeTag](preserving: c.Expr[Preserving], t1: c.Expr[CF.Expr[T1]])(
+    query: c.Expr[CF.Expr.Alias[T1] => CF.Query.Query0[R]]
+  ): c.Expr[CF.Query.Query0[R]] =
+    withImpl(query.tree, wildcard = false, preserving = Some(preserving), t1.tree -> weakTypeOf[T1])
+
+  def withPreserving2[T1: WeakTypeTag, T2: WeakTypeTag, R: WeakTypeTag](
+    preserving: c.Expr[Preserving],
+    t1: c.Expr[CF.Expr[T1]],
+    t2: c.Expr[CF.Expr[T2]]
+  )(query: c.Expr[(CF.Expr.Alias[T1], CF.Expr.Alias[T2]) => CF.Query.Query0[R]]): c.Expr[CF.Query.Query0[R]] =
+    withImpl(
+      query.tree,
+      wildcard   = false,
+      preserving = Some(preserving),
+      t1.tree -> weakTypeOf[T1],
+      t2.tree -> weakTypeOf[T2]
+    )
+
+  def withPreserving3[T1: WeakTypeTag, T2: WeakTypeTag, T3: WeakTypeTag, R: WeakTypeTag](
+    preserving: c.Expr[Preserving],
+    t1: c.Expr[CF.Expr[T1]],
+    t2: c.Expr[CF.Expr[T2]],
+    t3: c.Expr[CF.Expr[T3]]
+  )(
+    query: c.Expr[(CF.Expr.Alias[T1], CF.Expr.Alias[T2], CF.Expr.Alias[T3]) => CF.Query.Query0[R]]
+  ): c.Expr[CF.Query.Query0[R]] =
+    withImpl(
+      query.tree,
+      wildcard = false,
+      Some(preserving),
+      t1.tree -> weakTypeOf[T1],
+      t2.tree -> weakTypeOf[T2],
+      t3.tree -> weakTypeOf[T3]
+    )
+
+  def withPreserving4[T1: WeakTypeTag, T2: WeakTypeTag, T3: WeakTypeTag, T4: WeakTypeTag, R: WeakTypeTag](
+    preserving: c.Expr[Preserving],
+    t1: c.Expr[CF.Expr[T1]],
+    t2: c.Expr[CF.Expr[T2]],
+    t3: c.Expr[CF.Expr[T3]],
+    t4: c.Expr[CF.Expr[T4]]
+  )(
+    query: c.Expr[(CF.Expr.Alias[T1], CF.Expr.Alias[T2], CF.Expr.Alias[T3], CF.Expr.Alias[T4]) => CF.Query.Query0[R]]
+  ): c.Expr[CF.Query.Query0[R]] =
+    withImpl(
+      query.tree,
+      wildcard = false,
+      Some(preserving),
+      t1.tree -> weakTypeOf[T1],
+      t2.tree -> weakTypeOf[T2],
+      t3.tree -> weakTypeOf[T3],
+      t4.tree -> weakTypeOf[T4]
+    )
+
+  def withPreserving5[
+    T1: WeakTypeTag,
+    T2: WeakTypeTag,
+    T3: WeakTypeTag,
+    T4: WeakTypeTag,
+    T5: WeakTypeTag,
+    R: WeakTypeTag
+  ](
+    preserving: c.Expr[Preserving],
+    t1: c.Expr[CF.Expr[T1]],
+    t2: c.Expr[CF.Expr[T2]],
+    t3: c.Expr[CF.Expr[T3]],
+    t4: c.Expr[CF.Expr[T4]],
+    t5: c.Expr[CF.Expr[T5]]
+  )(
+    query: c.Expr[
+      (
+        CF.Expr.Alias[T1],
+        CF.Expr.Alias[T2],
+        CF.Expr.Alias[T3],
+        CF.Expr.Alias[T4],
+        CF.Expr.Alias[T5]
+      ) => CF.Query.Query0[R]
+    ]
+  ): c.Expr[CF.Query.Query0[R]] =
+    withImpl(
+      query.tree,
+      wildcard = false,
+      Some(preserving),
       t1.tree -> weakTypeOf[T1],
       t2.tree -> weakTypeOf[T2],
       t3.tree -> weakTypeOf[T3],
@@ -160,7 +257,12 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
 
   protected type ExprWithInnerType = (Tree, Type)
 
-  protected def withImpl[R](query: Tree, wildcard: Boolean, exprs: ExprWithInnerType*): c.Expr[CF.Query.Query0[R]] = {
+  protected def withImpl[R](
+    query: Tree,
+    wildcard: Boolean,
+    preserving: Option[c.Expr[Preserving]],
+    exprs: ExprWithInnerType*
+  ): c.Expr[CF.Query.Query0[R]] = {
     val (args, body0) = query match {
       case Function(args, body) => args -> body
       case _                    => Nil  -> query
@@ -176,8 +278,19 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
         ((nme, name), bind, ret)
       }
       .unzip3
+
+    val preserveValues = preserving.map { p =>
+      (p.tree match {
+        case Apply(_, l) =>
+          l.map { s =>
+            Seq(q"_root_.com.arkondata.slothql.cypher.CypherFragment.Return.Expr(..$s, None)")
+          }
+        case _ => c.abort(c.enclosingPosition, s"Preserving is not provided")
+      }).flatten
+    }.getOrElse(Seq.empty[c.Tree])
+
     val rebind = argNames.toMap
-    val return0 = (wildcard, returns) match {
+    val return0 = (wildcard, preserveValues ++ returns) match {
       case (false, Seq())       => c.abort(c.enclosingPosition, "No variables bound at WITH clause")
       case (false, Seq(single)) => single
       case (false, seq)         => q"_root_.com.arkondata.slothql.cypher.CypherFragment.Return.Tuple(_root_.scala.List(..$seq))"

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWithMacros.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxWithMacros.scala
@@ -88,6 +88,11 @@ class CypherSyntaxWithMacros(override val c: blackbox.Context) extends CypherSyn
   ): c.Expr[CF.Query.Query0[R]] =
     withImpl(query.tree, wildcard = true, None)
 
+  def withPreserving0[R: WeakTypeTag](preserving: c.Expr[Preserving])(
+    query: c.Expr[CF.Query.Query0[R]]
+  ): c.Expr[CF.Query.Query0[R]] =
+    withImpl(query.tree, wildcard = false, Some(preserving))
+
   def withWild1[T1: WeakTypeTag, R: WeakTypeTag](wildcard: c.Expr[**.type], t1: c.Expr[CF.Expr[T1]])(
     query: c.Expr[CF.Expr.Alias[T1] => CF.Query.Query0[R]]
   ): c.Expr[CF.Query.Query0[R]] =

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -109,7 +109,7 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     @compileTimeOnly("would have been replaced at With.apply")
     def limit(n: CF.Expr.Input[Long]): Nothing = ???
 
-    def preserving(exprs: CF.Expr[_] with CypherStatement.Alias*): Preserving = Preserving(exprs)
+    def preserving(expressions: CF.Expr[_] with CypherStatement.Alias*): Preserving = Preserving(expressions)
 
     def references[T1, R](n: CF.Expr[T1] with CypherStatement.Alias)(
       query: => CF.Query.Query0[R]
@@ -138,6 +138,9 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
 
     def apply[R](wildcard: **.type)(query: CF.Query.Query0[R]): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild0[R]
+
+    def apply[R](preserving: Preserving)(query: CF.Query.Query0[R]): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving0[R]
 
     // 1 Expr
 
@@ -478,6 +481,9 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
   object ::= {
     def unapply(any: Any): Option[(Path, Node)] = ???
   }
+
+  // Simplify Expression With //
+  def *(expressions: CF.Expr[_] with CypherStatement.Alias*): Preserving = With.preserving(expressions: _*)
 
   // // // // // // // // // // // // // // // // //
   // // // // //  Return Expressions  // // // // //

--- a/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
+++ b/cypher/src/main/scala/com/arkondata/slothql/cypher/syntax/package.scala
@@ -8,6 +8,7 @@ import cats.data.{ Ior, NonEmptyList }
 import shapeless.{ ::, =:!=, |∨|, ops, HList, HNil, Refute, Unpack1 }
 
 import com.arkondata.slothql.cypher.CypherFragment.Clause.Write
+import com.arkondata.slothql.cypher.CypherFragment.Expr.Alias.Preserving
 import com.arkondata.slothql.cypher.syntax.OnCreate.PartialCreateApply
 import com.arkondata.slothql.cypher.syntax.OnMatch.PartialMatchApply
 import com.arkondata.slothql.cypher.{ CypherFragment => CF }
@@ -108,6 +109,8 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     @compileTimeOnly("would have been replaced at With.apply")
     def limit(n: CF.Expr.Input[Long]): Nothing = ???
 
+    def preserving(exprs: CF.Expr[_] with CypherStatement.Alias*): Preserving = Preserving(exprs)
+
     def references[T1, R](n: CF.Expr[T1] with CypherStatement.Alias)(
       query: => CF.Query.Query0[R]
     ): CF.Query.Query0[R] = CF.Query.Clause(CF.Clause.With(CF.Return.Expr(n, None), None), query)
@@ -146,6 +149,11 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     ): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild1[T1, R]
 
+    def apply[T1, R](preserving: Preserving, t1: CF.Expr[T1])(
+      query: CF.Expr.Alias[T1] => CF.Query.Query0[R]
+    ): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving1[T1, R]
+
     // 2 Exprs
 
     def apply[T1, T2, R](t1: CF.Expr[T1], t2: CF.Expr[T2])(
@@ -157,6 +165,11 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       query: (CF.Expr.Alias[T1], CF.Expr.Alias[T2]) => CF.Query.Query0[R]
     ): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild2[T1, T2, R]
+
+    def apply[T1, T2, R](preserving: Preserving, t1: CF.Expr[T1], t2: CF.Expr[T2])(
+      query: (CF.Expr.Alias[T1], CF.Expr.Alias[T2]) => CF.Query.Query0[R]
+    ): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving2[T1, T2, R]
 
     // 3 Exprs
 
@@ -170,6 +183,11 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
     ): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild3[T1, T2, T3, R]
 
+    def apply[T1, T2, T3, R](preserving: Preserving, t1: CF.Expr[T1], t2: CF.Expr[T2], t3: CF.Expr[T3])(
+      query: (CF.Expr.Alias[T1], CF.Expr.Alias[T2], CF.Expr.Alias[T3]) => CF.Query.Query0[R]
+    ): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving3[T1, T2, T3, R]
+
     // 4 Exprs
 
     def apply[T1, T2, T3, T4, R](t1: CF.Expr[T1], t2: CF.Expr[T2], t3: CF.Expr[T3], t4: CF.Expr[T4])(
@@ -181,6 +199,17 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       query: (CF.Expr.Alias[T1], CF.Expr.Alias[T2], CF.Expr.Alias[T3], CF.Expr.Alias[T4]) => CF.Query.Query0[R]
     ): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild4[T1, T2, T3, T4, R]
+
+    def apply[T1, T2, T3, T4, R](
+      preserving: Preserving,
+      t1: CF.Expr[T1],
+      t2: CF.Expr[T2],
+      t3: CF.Expr[T3],
+      t4: CF.Expr[T4]
+    )(
+      query: (CF.Expr.Alias[T1], CF.Expr.Alias[T2], CF.Expr.Alias[T3], CF.Expr.Alias[T4]) => CF.Query.Query0[R]
+    ): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving4[T1, T2, T3, T4, R]
 
     // 5 Exprs
 
@@ -218,6 +247,24 @@ package object syntax extends CypherSyntaxLowPriorityImplicits {
       ) => CF.Query.Query0[R]
     ): CF.Query.Query0[R] =
       macro CypherSyntaxWithMacros.withWild5[T1, T2, T3, T4, T5, R]
+
+    def apply[T1, T2, T3, T4, T5, R](
+      preserving: Preserving,
+      t1: CF.Expr[T1],
+      t2: CF.Expr[T2],
+      t3: CF.Expr[T3],
+      t4: CF.Expr[T4],
+      t5: CF.Expr[T5]
+    )(
+      query: (
+        CF.Expr.Alias[T1],
+        CF.Expr.Alias[T2],
+        CF.Expr.Alias[T3],
+        CF.Expr.Alias[T4],
+        CF.Expr.Alias[T5]
+      ) => CF.Query.Query0[R]
+    ): CF.Query.Query0[R] =
+      macro CypherSyntaxWithMacros.withPreserving5[T1, T2, T3, T4, T5, R]
 
   }
 

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxBaseSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxBaseSpec.scala
@@ -24,8 +24,10 @@ trait CypherSyntaxBaseSpec extends AnyWordSpec with Matchers {
 
     def returns[R](implicit correct: T =:= R): Assertion = {
       val (CypherStatement.Complete(template, params), _) = query.toCypherF(cypherGen)
-      template shouldBe expectedTemplate
-      params shouldBe expectedParams
+      withClue(s"complete template: $template\n") {
+        template shouldBe expectedTemplate
+        params shouldBe expectedParams
+      }
     }
   }
 

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
@@ -129,6 +129,22 @@ class CypherSyntaxReadSpec extends CypherSyntaxBaseSpec {
       "RETURN `a0`, `c0`"
     ).returns[(Map[String, Any], Map[String, Any])]
 
+    "support no aliasing with" in
+    test(
+      Match { case (a @ Node("Node")) - Rel("to") > (b @ Node("Node")) =>
+        Match {
+          case c if c.prop[Int]("z") === a.prop[Int]("xyz") =>
+            With(With.preserving(a, b), c.prop[Int]("z")) { z =>
+              (a.props, z)
+            }
+        }
+      },
+      "MATCH (`a0`:`Node`) -[:`to`]-> (`b0`:`Node`) " +
+      "MATCH (`c0`) WHERE `c0`.`z` = `a0`.`xyz` " +
+      "WITH `a0`, `b0`, `c0`.`z` AS `z0` " +
+      "RETURN `a0`, `z0`"
+    ).returns[(Map[String, Any], Int)]
+
     "not allow to use identifiers excluded by WITH" in pending
 
     "support WHERE condition at WITH clause" in

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
@@ -134,7 +134,8 @@ class CypherSyntaxReadSpec extends CypherSyntaxBaseSpec {
       Match { case (a @ Node("Node")) - Rel("to") > (b @ Node("Node")) =>
         Match {
           case c if c.prop[Int]("z") === a.prop[Int]("xyz") =>
-            With(*(a, b)) {
+            val v = Seq(b)
+            With(*(a).also(v)) {
               a.props
             }
         }

--- a/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
+++ b/cypher/src/test/scala/com/arkondata/slothql/cypher/syntax/CypherSyntaxReadSpec.scala
@@ -129,12 +129,28 @@ class CypherSyntaxReadSpec extends CypherSyntaxBaseSpec {
       "RETURN `a0`, `c0`"
     ).returns[(Map[String, Any], Map[String, Any])]
 
+    "support no aliasing with no values" in
+    test(
+      Match { case (a @ Node("Node")) - Rel("to") > (b @ Node("Node")) =>
+        Match {
+          case c if c.prop[Int]("z") === a.prop[Int]("xyz") =>
+            With(*(a, b)) {
+              a.props
+            }
+        }
+      },
+      "MATCH (`a0`:`Node`) -[:`to`]-> (`b0`:`Node`) " +
+      "MATCH (`c0`) WHERE `c0`.`z` = `a0`.`xyz` " +
+      "WITH `a0`, `b0` " +
+      "RETURN `a0`"
+    ).returns[Map[String, Any]]
+
     "support no aliasing with" in
     test(
       Match { case (a @ Node("Node")) - Rel("to") > (b @ Node("Node")) =>
         Match {
           case c if c.prop[Int]("z") === a.prop[Int]("xyz") =>
-            With(With.preserving(a, b), c.prop[Int]("z")) { z =>
+            With(*(a, b), c.prop[Int]("z")) { z =>
               (a.props, z)
             }
         }


### PR DESCRIPTION
### Syntax merge `WITH` sentence with and without alias

```neo4j
MATCH (`a0`:`Node`) -[:`to`]-> (`b0`:`Node`) 
MATCH (`c0`) WHERE `c0`.`z` = `a0`.`xyz` 
WITH `a0`, `b0`, `c0`.`z` AS `z0` 
RETURN `a0`, `z0`
```
This sentence was generated with:
```scala
 Match { case (a @ Node("Node")) - Rel("to") > (b @ Node("Node")) =>
    Match {
      case c if c.prop[Int]("z") === a.prop[Int]("xyz") =>
        With(*(a, b), c.prop[Int]("z")) { z =>
          (a.props, z)
        }
    }
  }
```